### PR TITLE
added fix to look past keywords starting with END

### DIFF
--- a/dfits.c
+++ b/dfits.c
@@ -172,7 +172,8 @@ int dump_fits_filter(FILE * in, int xtnum)
 			printf("%s\n", rstrip(buf));
 			if (buf[0]=='E' &&
 				buf[1]=='N' &&
-				buf[2]=='D') {
+				buf[2]=='D' &&
+                                buf[8]!='=') {
 				break ;
 			}
 		}


### PR DESCRIPTION
I've added a fix for weird cases with FITS keywords starting with END (see example below) that triggered the abort code; this meant that all keywords after the ENDxxxx keyword just got ignored.

example:

```
TITLE   = 'zero              ' / Title
ORIGIN  = 'NOAO Monsoon GUI  ' / FITS file originator
DARKTIME=                  0.0 / total elapsed time, seconds
UT      = '11:55:17.44       ' / universal time (start of exposure)
UTSHUT  = '11:55:17.18       ' / UT of shutter close
ENDTIME =       2460060.205567 / msd end of exposure
READTIME=                 45.0 / CCD readout time (sec)
PREFLASH=                    0 / preflash time, seconds
GAIN    =                0.438 / gain, electrons per adu
DWELL   =                    4 / sample integration time, microseconds
```

before, this was the output of dfits
```
TITLE   = 'zero              ' / Title
ORIGIN  = 'NOAO Monsoon GUI  ' / FITS file originator
DARKTIME=                  0.0 / total elapsed time, seconds
UT      = '11:55:17.44       ' / universal time (start of exposure)
UTSHUT  = '11:55:17.18       ' / UT of shutter close
ENDTIME =       2460060.205567 / msd end of exposure
```
